### PR TITLE
feat: 安裝 agent-sdk-dev 插件（來自 claude-plugins-official）

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "enabledPlugins": {
+    "agent-sdk-dev@claude-plugins-official": true
+  }
+}


### PR DESCRIPTION
為專案啟用 Claude Agent SDK 開發插件，提供 SDK 專案建置與驗證功能。

https://claude.ai/code/session_01P2xXqkvAS1joo5zKK8XAKL