### PR TITLE
feat: migrate all Claude models to claude-opus-4-7

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -4,37 +4,37 @@
 assistants:
   manager:
     name: "Manager (主管)"
-    model: "claude-3-haiku-20240307"
+    model: "claude-opus-4-7"
     max_tokens: 4096
     temperature: 0.7
 
   personnel_a:
     name: "人員 A (行銷企劃)"
-    model: "claude-3-haiku-20240307"
+    model: "claude-opus-4-7"
     max_tokens: 4096
     temperature: 0.7
 
   personnel_b:
     name: "人員 B (數位行銷)"
-    model: "claude-3-haiku-20240307"
+    model: "claude-opus-4-7"
     max_tokens: 4096
     temperature: 0.7
 
   personnel_c:
     name: "人員 C (視覺設計)"
-    model: "claude-3-haiku-20240307"
+    model: "claude-opus-4-7"
     max_tokens: 4096
     temperature: 0.7
 
   personnel_d:
     name: "人員 D (美編專員)"
-    model: "claude-3-haiku-20240307"
+    model: "claude-opus-4-7"
     max_tokens: 4096
     temperature: 0.7
 
   personnel_e:
     name: "人員 E (團購PM)"
-    model: "claude-3-haiku-20240307"
+    model: "claude-opus-4-7"
     max_tokens: 4096
     temperature: 0.7
 

--- a/examples/api_usage.py
+++ b/examples/api_usage.py
@@ -42,7 +42,7 @@ def example_anthropic():
 
     try:
         # 創建客戶端
-        client = AnthropicClient(model="claude-3-5-sonnet-20241022")
+        client = AnthropicClient(model="claude-opus-4-7")
 
         # 發送聊天請求
         messages = [

--- a/src/api/anthropic_client.py
+++ b/src/api/anthropic_client.py
@@ -12,7 +12,7 @@ class AnthropicClient:
     """Anthropic Claude API 客戶端"""
 
     def __init__(
-        self, api_key: Optional[str] = None, model: str = "claude-3-haiku-20240307"
+        self, api_key: Optional[str] = None, model: str = "claude-opus-4-7"
     ):
         """
         初始化 Anthropic 客戶端
@@ -33,7 +33,6 @@ class AnthropicClient:
         self,
         messages: List[Dict[str, str]],
         system: Optional[str] = None,
-        temperature: float = 0.7,
         max_tokens: int = 4096,
     ) -> str:
         """
@@ -42,7 +41,6 @@ class AnthropicClient:
         Args:
             messages: 對話訊息列表
             system: 系統提示詞
-            temperature: 溫度參數
             max_tokens: 最大 token 數
 
         Returns:
@@ -53,7 +51,6 @@ class AnthropicClient:
             kwargs = {
                 "model": self.model,
                 "messages": messages,
-                "temperature": temperature,
                 "max_tokens": max_tokens,
             }
 

--- a/src/assistants/base_assistant.py
+++ b/src/assistants/base_assistant.py
@@ -32,7 +32,7 @@ class BaseAssistant(ABC):
 
         # 載入配置
         self.config = config.get_assistant_config(assistant_type)
-        model = self.config.get("model", "claude-3-5-sonnet-20241022")
+        model = self.config.get("model", "claude-opus-4-7")
         self.temperature = self.config.get("temperature", 0.7)
         self.max_tokens = self.config.get("max_tokens", 4096)
 
@@ -89,7 +89,6 @@ class BaseAssistant(ABC):
                 response = self.client.chat(
                     messages=self.conversation_history,
                     system=self.system_prompt,
-                    temperature=self.temperature,
                     max_tokens=self.max_tokens,
                 )
             else:


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Updated all 6 assistant model configs in `config/config.yaml` from retired/deprecated models to `claude-opus-4-7`
- Removed `temperature` parameter from `AnthropicClient.chat()` — Opus 4.7 returns a 400 error if `temperature` is sent; the OpenAI path is unaffected
- Updated the fallback model string in `base_assistant.py` and the example in `examples/api_usage.py`

## Breaking changes fixed

| File | Before | Issue |
|---|---|---|
| `config/config.yaml` (×6) | `claude-3-haiku-20240307` | Deprecated (retiring Apr 19) |
| `src/assistants/base_assistant.py` | `claude-3-5-sonnet-20241022` | Already retired (404 since Oct 2025) |
| `examples/api_usage.py` | `claude-3-5-sonnet-20241022` | Same |
| `src/api/anthropic_client.py` | passed `temperature` to API | Opus 4.7 returns 400 on any sampling param |

## Test plan

- [ ] Run one assistant end-to-end and confirm `response.model` starts with `claude-opus-4-7`
- [ ] Confirm no 400 errors in logs related to `temperature` or model ID

https://claude.ai/code/session_016f8rBvUGb7J2seLq5hB57b
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_016f8rBvUGb7J2seLq5hB57b)_